### PR TITLE
Hidden-today badge + community selector suggestions

### DIFF
--- a/.github/ISSUE_TEMPLATE/selector-request.yml
+++ b/.github/ISSUE_TEMPLATE/selector-request.yml
@@ -1,27 +1,35 @@
-name: Selector request
-description: Suggest a critic/fan rating or review element that In My Opinion should hide.
-title: "[Selector request] "
+name: Suggest a rating to hide
+description: Suggest a critic or fan rating (or review) that In My Opinion should hide.
+title: "Hide ratings on "
 labels:
   - selector-request
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve **In My Opinion**! Give a 👍 on requests
-        you'd also like to see added, so the most-wanted ones rise to the top.
+        Thanks for helping improve **In My Opinion**!
+
+        Use this to suggest a rating or review the extension should hide on a
+        site it doesn't cover yet. A few tips:
+
+        - Add the site and a page link so we can see the same thing you do.
+        - A screenshot (just drag it into the description) makes it much easier.
+        - You don't need to know any code. The last field is optional.
+
+        Give a 👍 on requests you'd like to see added, so the most-wanted ones rise to the top.
   - type: input
     id: site
     attributes:
       label: Site
-      description: The website's hostname.
+      description: The website's name or address.
       placeholder: e.g. rottentomatoes.com
     validations:
       required: true
   - type: input
     id: page_url
     attributes:
-      label: Page URL
-      description: A page where the rating/review appears (helps us reproduce it).
+      label: Page link
+      description: A page where the rating or review shows up.
       placeholder: https://...
     validations:
       required: false
@@ -29,15 +37,16 @@ body:
     id: what
     attributes:
       label: What should be hidden?
-      description: Describe the rating or review element you'd like removed.
-      placeholder: e.g. the Tomatometer / Audience Score box near the top.
+      description: Describe the rating or review you'd like removed. A screenshot helps a lot.
+      placeholder: e.g. the Tomatometer and Audience Score near the top of the page.
     validations:
       required: true
   - type: input
     id: selector
     attributes:
-      label: CSS selector (optional)
-      description: If you know it, a CSS selector that targets the element.
+      label: CSS selector (optional, advanced)
+      description: If you happen to know it, a CSS selector that targets the element.
       placeholder: e.g. [data-testid="rating"], .audience-score
     validations:
       required: false
+

--- a/.github/ISSUE_TEMPLATE/selector-request.yml
+++ b/.github/ISSUE_TEMPLATE/selector-request.yml
@@ -7,9 +7,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve **In My Opinion**! Suggestions collected here
-        power the public [suggestion board](https://alecbreton.com) — give a 👍
-        on requests you'd also like to see added.
+        Thanks for helping improve **In My Opinion**! Give a 👍 on requests
+        you'd also like to see added, so the most-wanted ones rise to the top.
   - type: input
     id: site
     attributes:

--- a/.github/ISSUE_TEMPLATE/selector-request.yml
+++ b/.github/ISSUE_TEMPLATE/selector-request.yml
@@ -1,0 +1,44 @@
+name: Selector request
+description: Suggest a critic/fan rating or review element that In My Opinion should hide.
+title: "[Selector request] "
+labels:
+  - selector-request
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve **In My Opinion**! Suggestions collected here
+        power the public [suggestion board](https://alecbreton.com) — give a 👍
+        on requests you'd also like to see added.
+  - type: input
+    id: site
+    attributes:
+      label: Site
+      description: The website's hostname.
+      placeholder: e.g. rottentomatoes.com
+    validations:
+      required: true
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: A page where the rating/review appears (helps us reproduce it).
+      placeholder: https://...
+    validations:
+      required: false
+  - type: textarea
+    id: what
+    attributes:
+      label: What should be hidden?
+      description: Describe the rating or review element you'd like removed.
+      placeholder: e.g. the Tomatometer / Audience Score box near the top.
+    validations:
+      required: true
+  - type: input
+    id: selector
+    attributes:
+      label: CSS selector (optional)
+      description: If you know it, a CSS selector that targets the element.
+      placeholder: e.g. [data-testid="rating"], .audience-score
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/selector-request.yml
+++ b/.github/ISSUE_TEMPLATE/selector-request.yml
@@ -1,6 +1,6 @@
 name: Suggest a rating to hide
 description: Suggest a critic or fan rating (or review) that In My Opinion should hide.
-title: "Hide ratings on "
+title: "[Selector Request] - Hide ratings on <site>"
 labels:
   - selector-request
 body:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ npm run build:check
 
 To load the extension locally, build it and then load the project directory as an unpacked extension (Chrome: `chrome://extensions` → *Load unpacked*; Firefox: `about:debugging` → *Load Temporary Add-on* → select `manifest-firefox.json`).
 
+## Hidden-today badge
+
+`background.js` runs as a background service worker (MV3) / background script (MV2). Content scripts message it with how many rating elements they hid; it keeps a per-day tally in `chrome.storage.local` and shows the total as the integer badge on the toolbar icon. The count resets at local midnight and clears when the extension is toggled off. `background.js` is shared verbatim across targets and is wired into each manifest by the build config.
+
+## Suggestion board
+
+The popup's *Suggest something to hide* link opens a prefilled GitHub issue form (`.github/ISSUE_TEMPLATE/selector-request.yml`) that captures the site, page URL, and (optionally) a CSS selector. Submitted issues carry the `selector-request` label and feed a public upvote board, where a 👍 reaction counts as an upvote. The board is a standalone static page that reads the GitHub API client-side — no server or database — and lives with the website rather than in this extension package.
+
+
 <br/>
 
 *Developed By: Alec Breton (acbreton)*

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To load the extension locally, build it and then load the project directory as a
 
 `background.js` runs as a background service worker (MV3) / background script (MV2). Content scripts message it with how many rating elements they hid; it keeps a per-day tally in `chrome.storage.local` and shows the total as the integer badge on the toolbar icon. The count resets at local midnight and clears when the extension is toggled off. `background.js` is shared verbatim across targets and is wired into each manifest by the build config.
 
-## Suggestion board
+## Suggestions
 
-The popup's *Suggest something to hide* link opens a prefilled GitHub issue form (`.github/ISSUE_TEMPLATE/selector-request.yml`) that captures the site, page URL, and (optionally) a CSS selector. Submitted issues carry the `selector-request` label and feed a public upvote board, where a 👍 reaction counts as an upvote. The board is a standalone static page that reads the GitHub API client-side — no server or database — and lives with the website rather than in this extension package.
+The popup's *Suggest something to hide* link opens a prefilled GitHub issue form (`.github/ISSUE_TEMPLATE/selector-request.yml`) that captures the site, page URL, and (optionally) a CSS selector. Submitted issues carry the `selector-request` label, and 👍 reactions act as upvotes so the most-wanted requests rise to the top. The issue list itself serves as the suggestion board.
 
 
 <br/>

--- a/background.js
+++ b/background.js
@@ -1,0 +1,65 @@
+"use strict";
+
+// Maintains an adblock-style "hidden today" counter and renders it as the
+// integer badge on the extension icon. Content scripts report how many rating
+// elements they hid; this worker accumulates the total for the current day.
+//
+// The count resets at local midnight and is cleared whenever the extension is
+// toggled off. Badge state lives in the browser UI, so it survives the MV3
+// service worker being suspended between messages.
+
+const action = chrome.action || chrome.browserAction;
+
+function todayKey() {
+    const d = new Date();
+    return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+}
+
+function renderBadge(count, enabled) {
+    if (!action || !action.setBadgeText) return;
+    const text = enabled && count > 0 ? String(count) : "";
+    action.setBadgeText({ text });
+}
+
+function refreshBadge() {
+    chrome.storage.local.get(["enabled", "hiddenCount", "hiddenDate"], (r) => {
+        const enabled = r.enabled !== undefined ? r.enabled : true;
+        const count = r.hiddenDate === todayKey() ? (r.hiddenCount || 0) : 0;
+        renderBadge(count, enabled);
+    });
+}
+
+function addHidden(delta) {
+    if (!delta || delta < 0) return;
+    chrome.storage.local.get(["enabled", "hiddenCount", "hiddenDate"], (r) => {
+        const enabled = r.enabled !== undefined ? r.enabled : true;
+        if (!enabled) return;
+        const today = todayKey();
+        const base = r.hiddenDate === today ? (r.hiddenCount || 0) : 0;
+        const count = base + delta;
+        chrome.storage.local.set({ hiddenCount: count, hiddenDate: today }, () => {
+            renderBadge(count, enabled);
+        });
+    });
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg && msg.type === "imo-hidden" && typeof msg.count === "number") {
+        addHidden(msg.count);
+    }
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === "local" && "enabled" in changes) {
+        refreshBadge();
+    }
+});
+
+if (action && action.setBadgeBackgroundColor) {
+    action.setBadgeBackgroundColor({ color: "#555555" });
+}
+
+if (chrome.runtime.onStartup) chrome.runtime.onStartup.addListener(refreshBadge);
+if (chrome.runtime.onInstalled) chrome.runtime.onInstalled.addListener(refreshBadge);
+
+refreshBadge();

--- a/build/build-manifests.js
+++ b/build/build-manifests.js
@@ -30,6 +30,7 @@ function buildManifest(target) {
         [target.actionKey]: action,
         icons: shared.icons,
         content_scripts: contentScripts(target.googleSubdomains),
+        ...(target.background ? { background: target.background } : {}),
         manifest_version: target.manifestVersion,
         ...(target.extra || {}),
     };

--- a/build/manifest.config.js
+++ b/build/manifest.config.js
@@ -49,7 +49,7 @@ function contentScripts(subdomains) {
 const targets = {
     // Chrome, loaded unpacked for development (also targets the Play store).
     "manifest.json": {
-        version: "1.2.1",
+        version: "1.3.0",
         manifestVersion: 3,
         actionKey: "action",
         permissions: ["storage", "activeTab"],
@@ -58,7 +58,7 @@ const targets = {
     },
     // Chrome Web Store submission build.
     "manifest-google-v3.json": {
-        version: "1.2.1",
+        version: "1.3.0",
         manifestVersion: 3,
         actionKey: "action",
         permissions: ["storage", "activeTab"],
@@ -67,7 +67,7 @@ const targets = {
     },
     // Firefox Add-ons (Manifest V2).
     "manifest-firefox.json": {
-        version: "1.1",
+        version: "1.2",
         manifestVersion: 2,
         actionKey: "browser_action",
         permissions: ["*://www.google.com/*", "*://www.imdb.com/*", "storage", "activeTab"],

--- a/build/manifest.config.js
+++ b/build/manifest.config.js
@@ -52,24 +52,27 @@ const targets = {
         version: "1.2.1",
         manifestVersion: 3,
         actionKey: "action",
-        permissions: ["storage"],
+        permissions: ["storage", "activeTab"],
         googleSubdomains: ["www", "play"],
+        background: { service_worker: "background.js" },
     },
     // Chrome Web Store submission build.
     "manifest-google-v3.json": {
         version: "1.2.1",
         manifestVersion: 3,
         actionKey: "action",
-        permissions: ["storage"],
+        permissions: ["storage", "activeTab"],
         googleSubdomains: ["www"],
+        background: { service_worker: "background.js" },
     },
     // Firefox Add-ons (Manifest V2).
     "manifest-firefox.json": {
         version: "1.1",
         manifestVersion: 2,
         actionKey: "browser_action",
-        permissions: ["*://www.google.com/*", "*://www.imdb.com/*", "storage"],
+        permissions: ["*://www.google.com/*", "*://www.imdb.com/*", "storage", "activeTab"],
         googleSubdomains: ["www"],
+        background: { scripts: ["background.js"], persistent: false },
         extra: {
             browser_specific_settings: {
                 gecko: { id: "{1e883c16-fc94-4cf8-b58f-f34b445f632e}" },

--- a/contentScript.js
+++ b/contentScript.js
@@ -33,6 +33,28 @@ function getSiteKey() {
     return null;
 }
 
+// Counts each hidden rating element once for the "hidden today" badge and
+// reports the delta to the background worker.
+const counted = new WeakSet();
+
+function reportHiddenForSite(site) {
+    const selectors = CLASSNAMES_TO_REMOVE[site].join(', ');
+    let n = 0;
+    document.querySelectorAll(selectors).forEach((el) => {
+        if (!counted.has(el)) {
+            counted.add(el);
+            n++;
+        }
+    });
+    if (n > 0) {
+        try {
+            chrome.runtime.sendMessage({ type: "imo-hidden", count: n });
+        } catch (e) {
+            /* worker unavailable; badge is best-effort */
+        }
+    }
+}
+
 
 function log(message) {
     if (!isProdMode) {
@@ -54,6 +76,8 @@ function hideElementsForSite() {
     log(`Injected CSS to hide elements with class: ${CLASSNAMES_TO_REMOVE[site]}`);
 
     document.head.appendChild(blockStyleElement);
+
+    reportHiddenForSite(site);
 }
 
 function showElementsForSite() {

--- a/contentScriptGoogle.js
+++ b/contentScriptGoogle.js
@@ -28,6 +28,48 @@ let isEnabled = true;
 let observer = null;
 let scheduled = false;
 
+// "Hidden today" badge accounting. We count each element only once (via a
+// WeakSet) and batch the deltas so the background worker isn't spammed on every
+// mutation-observer tick.
+const counted = new WeakSet();
+let pendingCount = 0;
+let reportScheduled = false;
+
+function reportHidden(n) {
+    if (n > 0) pendingCount += n;
+    if (reportScheduled || pendingCount === 0) return;
+    reportScheduled = true;
+    setTimeout(() => {
+        reportScheduled = false;
+        const c = pendingCount;
+        pendingCount = 0;
+        if (c > 0) {
+            try {
+                chrome.runtime.sendMessage({ type: "imo-hidden", count: c });
+            } catch (e) {
+                /* worker unavailable; badge is best-effort */
+            }
+        }
+    }, 500);
+}
+
+function countNewlyHidden() {
+    let n = 0;
+    document.querySelectorAll(SELECTORS_TO_HIDE.join(", ")).forEach((el) => {
+        if (!counted.has(el)) {
+            counted.add(el);
+            n++;
+        }
+    });
+    document.querySelectorAll(`.${HIDDEN_CLASS}`).forEach((el) => {
+        if (!counted.has(el)) {
+            counted.add(el);
+            n++;
+        }
+    });
+    reportHidden(n);
+}
+
 function buildStyle() {
     const style = document.createElement("style");
     style.id = STYLE_ID;
@@ -71,6 +113,8 @@ function tagAncestors() {
             if (row) row.classList.add(HIDDEN_CLASS);
         }
     });
+
+    countNewlyHidden();
 }
 
 function clearTags() {

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -6,7 +6,8 @@
     "permissions": [
         "*://www.google.com/*",
         "*://www.imdb.com/*",
-        "storage"
+        "storage",
+        "activeTab"
     ],
     "browser_action": {
         "default_title": "In My Opinion",
@@ -234,6 +235,12 @@
             "run_at": "document_start"
         }
     ],
+    "background": {
+        "scripts": [
+            "background.js"
+        ],
+        "persistent": false
+    },
     "manifest_version": 2,
     "browser_specific_settings": {
         "gecko": {

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
     "name": "In My Opinion",
     "short_name": "IMO",
-    "version": "1.1",
+    "version": "1.2",
     "description": "A Google Chrome extension for removing critic and fan review ratings from search results and various popular webpages.",
     "permissions": [
         "*://www.google.com/*",

--- a/manifest-google-v3.json
+++ b/manifest-google-v3.json
@@ -4,7 +4,8 @@
     "version": "1.2.1",
     "description": "A Google Chrome extension for removing critic and fan review ratings from search results and various popular webpages.",
     "permissions": [
-        "storage"
+        "storage",
+        "activeTab"
     ],
     "action": {
         "default_title": "In My Opinion",
@@ -232,5 +233,8 @@
             "run_at": "document_start"
         }
     ],
+    "background": {
+        "service_worker": "background.js"
+    },
     "manifest_version": 3
 }

--- a/manifest-google-v3.json
+++ b/manifest-google-v3.json
@@ -1,7 +1,7 @@
 {
     "name": "In My Opinion",
     "short_name": "IMO",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "A Google Chrome extension for removing critic and fan review ratings from search results and various popular webpages.",
     "permissions": [
         "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,8 @@
     "version": "1.2.1",
     "description": "A Google Chrome extension for removing critic and fan review ratings from search results and various popular webpages.",
     "permissions": [
-        "storage"
+        "storage",
+        "activeTab"
     ],
     "action": {
         "default_title": "In My Opinion",
@@ -422,5 +423,8 @@
             "run_at": "document_start"
         }
     ],
+    "background": {
+        "service_worker": "background.js"
+    },
     "manifest_version": 3
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "In My Opinion",
     "short_name": "IMO",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "A Google Chrome extension for removing critic and fan review ratings from search results and various popular webpages.",
     "permissions": [
         "storage",

--- a/modal/modal.css
+++ b/modal/modal.css
@@ -11,7 +11,7 @@ body {
 .mainContent {
   display: flex;
   flex-flow: column;
-  width: 300px; 
+  width: 380px; 
 }
 
 .extensionIntroduction {

--- a/modal/modal.css
+++ b/modal/modal.css
@@ -134,7 +134,8 @@ input:checked + .slider:before {
 }
 
 #webStoreLink,
-#reviewLink {
+#reviewLink,
+#reportLink {
   font-weight: bold;
   color: blue;
   cursor: pointer;

--- a/modal/modal.html
+++ b/modal/modal.html
@@ -19,6 +19,8 @@
                         <span id="webStoreLink">\\ Store Page</span>
                         <br>
                         <span id="reviewLink">\\ Write Review</span>
+                        <br>
+                        <span id="reportLink">\\ Suggest something to hide</span>
                     </div>
                 </div>
             </div>

--- a/modal/modal.js
+++ b/modal/modal.js
@@ -54,7 +54,7 @@ function openReportLink() {
             template: "selector-request.yml",
             labels: "selector-request",
         });
-        if (host) params.set("title", `[Selector request] ${host}`);
+        if (host) params.set("title", `Hide ratings on ${host}`);
         if (host) params.set("site", host);
         if (pageUrl) params.set("page_url", pageUrl);
 

--- a/modal/modal.js
+++ b/modal/modal.js
@@ -36,7 +36,7 @@ function openRateLink() {
 
 // Opens a prefilled GitHub issue form so users can suggest a rating/review
 // element to hide. The active tab's URL and hostname are captured to give the
-// report context. These labeled issues power the public suggestion board.
+// report context. These labeled issues are the running list of suggestions.
 const REPO = "acbreton/in_my_opinion";
 
 function openReportLink() {

--- a/modal/modal.js
+++ b/modal/modal.js
@@ -16,8 +16,10 @@ chrome.storage.local.get("enabled", (result) => {
 document.addEventListener("DOMContentLoaded", () => {
     let webStoreLink = document.getElementById("webStoreLink");
     let rateLink = document.getElementById("reviewLink");
+    let reportLink = document.getElementById("reportLink");
     webStoreLink.addEventListener("click", openStoreLink);
     rateLink.addEventListener("click", openRateLink);
+    reportLink.addEventListener("click", openReportLink);
 });
 
 function openStoreLink() {
@@ -30,4 +32,35 @@ function openRateLink() {
     chrome.tabs.create({
         active: true, url: "https://chrome.google.com/webstore/detail/in-my-opinion/lkopodamggoocbopennlkmhbmhohlkdc/reviews"
     })
+}
+
+// Opens a prefilled GitHub issue form so users can suggest a rating/review
+// element to hide. The active tab's URL and hostname are captured to give the
+// report context. These labeled issues power the public suggestion board.
+const REPO = "acbreton/in_my_opinion";
+
+function openReportLink() {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const tab = tabs && tabs[0];
+        const pageUrl = tab && tab.url ? tab.url : "";
+        let host = "";
+        try {
+            host = pageUrl ? new URL(pageUrl).hostname : "";
+        } catch (e) {
+            host = "";
+        }
+
+        const params = new URLSearchParams({
+            template: "selector-request.yml",
+            labels: "selector-request",
+        });
+        if (host) params.set("title", `[Selector request] ${host}`);
+        if (host) params.set("site", host);
+        if (pageUrl) params.set("page_url", pageUrl);
+
+        chrome.tabs.create({
+            active: true,
+            url: `https://github.com/${REPO}/issues/new?${params.toString()}`,
+        });
+    });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "in-my-opinion",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "private": true,
     "description": "Browser extension that hides critic and fan review ratings from search results and popular webpages.",
     "scripts": {


### PR DESCRIPTION
Still WIP, but wanted to get it up.

A few things that seemed like they'd be useful:

- **Hidden-today badge.** Adds a little count on the extension icon, kind of like adblock does. It tallies how many rating elements got hidden today, resets at midnight, and clears when you toggle the extension off. This adds a small background worker (we didn't have one before).
- **"Suggest something to hide" link** in the popup. Opens a prefilled GitHub issue form with the site and page URL already filled in. Those issues become the running list of requests, and 👍 reactions act as upvotes, so no backend needed.
- **Issue template** (`selector-request.yml`) to keep those submissions structured. GitHub Issues itself is the running list, and 👍 reactions act as upvotes, so no separate site or backend needed.

Notes:
- Added the `activeTab` permission so the popup can read the current tab URL. Seems minor but it'll show a permission note on the store update.
- Didn't bump versions since that felt like a release decision.
- Manifests are regenerated via the build config, so the background worker is wired into all three.

Happy to change any of it.
